### PR TITLE
feat(ui): implement Notification and DropdownMenu components

### DIFF
--- a/apps/service/app/page.tsx
+++ b/apps/service/app/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import React from 'react';
 import { NavColumn, NavContainer, NavItem, NavText } from '@akacords-frontend/ui';

--- a/packages/ui/src/components/Divider/Divider.stories.tsx
+++ b/packages/ui/src/components/Divider/Divider.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Divider } from './index';
+
+export default {
+  component: Divider
+} as ComponentMeta<typeof Divider>;
+
+const Template: ComponentStory<typeof Divider> = (args) => <Divider {...args} />;
+
+export const Primary = Template.bind({});

--- a/packages/ui/src/components/Divider/index.tsx
+++ b/packages/ui/src/components/Divider/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+interface DividerProps {
+  readonly width?: number;
+}
+
+export function Divider({ width }: DividerProps) {
+  const widthStyle = width === undefined ? 'w-full' : `w-[${width}px]`;
+  return <div className={`${widthStyle} h-[1px] bg-[#F2F2F2] my-1`} />;
+}

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Like1, MenuBoard, Trash } from 'iconsax-react';
+import { Divider, DropdownMenuContainer, DropdownMenuItem } from '@src/components';
+
+export default {
+  component: DropdownMenuContainer
+} as ComponentMeta<typeof DropdownMenuContainer>;
+
+const Template: ComponentStory<typeof DropdownMenuContainer> = (args) => {
+  return (
+    <DropdownMenuContainer {...args}>
+      <DropdownMenuItem title="메모장" icon={<MenuBoard size={16} />} side={<p>Alt+D</p>} />
+      <DropdownMenuItem title="좋아요" icon={<Like1 size={16} />} side={<p>⌘D</p>} />
+      <Divider />
+      <DropdownMenuItem title="로그아웃" icon={<Trash size={16} />} />
+    </DropdownMenuContainer>
+  );
+};
+export const Primary = Template.bind({});

--- a/packages/ui/src/components/DropdownMenu/DropdownMenuContainer.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenuContainer.tsx
@@ -1,0 +1,9 @@
+import React, { PropsWithChildren } from 'react';
+
+export function DropdownMenuContainer({ children }: PropsWithChildren) {
+  return (
+    <div className="w-60 rounded-lg shadow-[0_0_16px_16px_rgba(0,0,0,0.1)] p-2">
+      <div className="flex flex-col items-center">{children}</div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenuItem.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from 'react';
+
+interface DropdownMenuItemProps {
+  readonly title: string;
+  readonly icon: ReactElement;
+  readonly side?: ReactElement;
+}
+
+export function DropdownMenuItem({ title, icon, side }: DropdownMenuItemProps) {
+  return (
+    <div className="w-56 h-9 p-2 rounded-lg flex items-center cursor-pointer hover:bg-[#F2F4F7] justify-between">
+      <div className="flex flex-row items-center">
+        <>
+          {icon}
+          <span className="ml-2 text-sm">{title}</span>
+        </>
+      </div>
+      {side !== undefined && <div className="text-black opacity-40 text-xs">{side}</div>}
+    </div>
+  );
+}

--- a/packages/ui/src/components/DropdownMenu/index.ts
+++ b/packages/ui/src/components/DropdownMenu/index.ts
@@ -1,0 +1,2 @@
+export * from './DropdownMenuContainer';
+export * from './DropdownMenuItem';

--- a/packages/ui/src/components/Input/index.tsx
+++ b/packages/ui/src/components/Input/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useRef, useState } from 'react';
 import { InputBorderColorMap, InputStatus, LabelTextColorMap } from '@src/components/Input/constant';
 

--- a/packages/ui/src/components/NavigationBar/NavigationBar.stories.tsx
+++ b/packages/ui/src/components/NavigationBar/NavigationBar.stories.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { NavColumn, NavContainer, NavItem, NavText } from '@src/components/NavigationBar';

--- a/packages/ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/ui/src/components/Notification/Notification.stories.tsx
@@ -8,7 +8,7 @@ export default {
 
 const DefaultNotification: ComponentStory<typeof NotificationContainer> = (args) => {
   return (
-    <NotificationContainer>
+    <NotificationContainer {...args}>
       <NotificationItem title="제목" body="내용" />
       <NotificationItem
         title="제목2"
@@ -20,7 +20,7 @@ const DefaultNotification: ComponentStory<typeof NotificationContainer> = (args)
 
 const EmptyNotification: ComponentStory<typeof NotificationContainer> = (args) => {
   return (
-    <NotificationContainer>
+    <NotificationContainer {...args}>
       <NotificationEmptyItem />
     </NotificationContainer>
   );

--- a/packages/ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/ui/src/components/Notification/Notification.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { NotificationContainer, NotificationEmptyItem, NotificationItem } from '@src/components';
+
+export default {
+  component: NotificationContainer
+} as ComponentMeta<typeof NotificationContainer>;
+
+const DefaultNotification: ComponentStory<typeof NotificationContainer> = (args) => {
+  return (
+    <NotificationContainer>
+      <NotificationItem title="제목" body="내용" />
+      <NotificationItem
+        title="제목2"
+        body="국방상 또는 국민경제상 긴절한 필요로 인하여 법률이 정하는 경우를 제외하고는, 사영기업을 국유 또는 공유로 이전하거나 그 경영을 통제 또는 관리할 수 없다."
+      />
+    </NotificationContainer>
+  );
+};
+
+const EmptyNotification: ComponentStory<typeof NotificationContainer> = (args) => {
+  return (
+    <NotificationContainer>
+      <NotificationEmptyItem />
+    </NotificationContainer>
+  );
+};
+
+export const Primary = DefaultNotification.bind({});
+export const Empty = EmptyNotification.bind({});

--- a/packages/ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/ui/src/components/Notification/Notification.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { NotificationContainer, NotificationEmptyItem, NotificationItem } from '@src/components';
+import { Divider, NotificationContainer, NotificationEmptyItem, NotificationItem } from '@src/components';
 
 export default {
   component: NotificationContainer
@@ -10,6 +10,7 @@ const DefaultNotification: ComponentStory<typeof NotificationContainer> = (args)
   return (
     <NotificationContainer {...args}>
       <NotificationItem title="제목" body="내용" />
+      <Divider />
       <NotificationItem
         title="제목2"
         body="국방상 또는 국민경제상 긴절한 필요로 인하여 법률이 정하는 경우를 제외하고는, 사영기업을 국유 또는 공유로 이전하거나 그 경영을 통제 또는 관리할 수 없다."

--- a/packages/ui/src/components/Notification/NotificationContainer.tsx
+++ b/packages/ui/src/components/Notification/NotificationContainer.tsx
@@ -1,0 +1,12 @@
+import React, { PropsWithChildren } from 'react';
+
+export function NotificationContainer({ children }: PropsWithChildren) {
+  return (
+    <div className="w-60 rounded-lg shadow-[0_0_16px_16px_rgba(0,0,0,0.1)] p-2">
+      <div className="w-full h-9 p-2 flex items-center">
+        <p className="font-bold text-base">알림</p>
+      </div>
+      <div className="flex flex-col items-center">{children}</div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/Notification/NotificationEmptyItem.tsx
+++ b/packages/ui/src/components/Notification/NotificationEmptyItem.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export function NotificationEmptyItem() {
+  return (
+    <div className="w-[180px] h-[157px] flex justify-center items-center">
+      <p className="text-center text-xs">
+        알림이 없습니다.
+        <br />
+        많은 활동을 통해 알림을 받아보세요!
+      </p>
+    </div>
+  );
+}

--- a/packages/ui/src/components/Notification/NotificationItem.tsx
+++ b/packages/ui/src/components/Notification/NotificationItem.tsx
@@ -1,0 +1,23 @@
+import React, { MouseEventHandler } from 'react';
+
+interface NotificationItemProps {
+  readonly title: string;
+  readonly body: string;
+  readonly onClick?: MouseEventHandler<HTMLDivElement>;
+}
+
+export function NotificationItem({ title, body, onClick }: NotificationItemProps) {
+  return (
+    <div
+      className="w-56 h-[60px] p-2 rounded-[7px] cursor-pointer hover:bg-[#F2F4F7]"
+      onClick={onClick}
+      role="presentation"
+    >
+      <div className="flex flex-row items-center">
+        <div className="w-3 h-3 rounded-full bg-[#D9D9D9] mr-2" />
+        <p className="text-[14px] font-medium">{title}</p>
+      </div>
+      <p className="text-xs mt-1">{body}</p>
+    </div>
+  );
+}

--- a/packages/ui/src/components/Notification/NotificationItem.tsx
+++ b/packages/ui/src/components/Notification/NotificationItem.tsx
@@ -9,7 +9,7 @@ interface NotificationItemProps {
 export function NotificationItem({ title, body, onClick }: NotificationItemProps) {
   return (
     <div
-      className="w-56 h-[60px] p-2 rounded-[7px] cursor-pointer hover:bg-[#F2F4F7]"
+      className="w-56 min-h-[60px] p-2 rounded-[7px] cursor-pointer hover:bg-[#F2F4F7]"
       onClick={onClick}
       role="presentation"
     >

--- a/packages/ui/src/components/Notification/index.ts
+++ b/packages/ui/src/components/Notification/index.ts
@@ -1,0 +1,3 @@
+export * from './NotificationContainer';
+export * from './NotificationItem';
+export * from './NotificationEmptyItem';

--- a/packages/ui/src/components/ProfileDropdownMenu/ProfileDropdownMenu.stories.tsx
+++ b/packages/ui/src/components/ProfileDropdownMenu/ProfileDropdownMenu.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ProfileDropdownMenu } from '@src/components';
+
+export default {
+  component: ProfileDropdownMenu
+} as ComponentMeta<typeof ProfileDropdownMenu>;
+
+const Template: ComponentStory<typeof ProfileDropdownMenu> = (args) => <ProfileDropdownMenu {...args} />;
+
+export const Primary = Template.bind({});

--- a/packages/ui/src/components/ProfileDropdownMenu/index.tsx
+++ b/packages/ui/src/components/ProfileDropdownMenu/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface ProfileDropdownMenuProps {
+  readonly image: string;
+  readonly nickname: string;
+  readonly email: string;
+}
+
+export function ProfileDropdownMenu({ image, nickname, email }: ProfileDropdownMenuProps) {
+  return (
+    <div className="w-full h-9 flex items-center">
+      <div className="flex">
+        <img src={image} alt={`${nickname}님의 프로필사진`} className="rounded-full" />
+        <div className="flex flex-col ml-[10px]">
+          <p className="text-sm">{nickname}</p>
+          <p className="text-xs text-gray-400">{email}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -2,3 +2,4 @@ export * from './Input';
 export * from './NavigationBar';
 export * from './Divider';
 export * from './Notification';
+export * from './DropdownMenu';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './Input';
 export * from './NavigationBar';
+export * from './Divider';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './Input';
 export * from './NavigationBar';
 export * from './Divider';
+export * from './Notification';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -3,3 +3,4 @@ export * from './NavigationBar';
 export * from './Divider';
 export * from './Notification';
 export * from './DropdownMenu';
+export * from './ProfileDropdownMenu';


### PR DESCRIPTION
- Notification 컴포넌트 구현
  - Default notification component
    ![image](https://github.com/Fill-Die-Study/akacords-frontend/assets/12780464/1dc8e147-5468-442b-8a9a-dfa9e83f2cda)
  - Empty notification component
    ![image](https://github.com/Fill-Die-Study/akacords-frontend/assets/12780464/f1006ccb-e456-411d-a55c-c5ddb7fecf5e)
- DropdownMenu 컴포넌트 구현
  - `side` prop으로 오른쪽 끝에 특정 컴포넌트(텍스트, 버튼 등)를 추가할 수 있습니다.
  ![image](https://github.com/Fill-Die-Study/akacords-frontend/assets/12780464/3f4a6cf5-acb6-4cc6-9f80-dec1393238b2)
- ProfileDropdownMenu 컴포넌트 구현
  - DropdownMenu에 프로필을 표시하기 위해 사용합니다.  
  ![image](https://github.com/Fill-Die-Study/akacords-frontend/assets/12780464/70e13a97-c8e8-4871-920e-689e503f5c8f)
